### PR TITLE
Change default perceptualPrecision to 0.99

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -28,7 +28,7 @@
     ///   - drawingMode: The drawing mode.
     public static func image(
       precision: Float = 1,
-      perceptualPrecision: Float = 1,
+      perceptualPrecision: Float = 0.99,
       drawingMode: CGPathDrawingMode = .eoFill
     ) -> Snapshotting {
       return SimplySnapshotting.image(
@@ -67,7 +67,7 @@
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1,
+      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat = 1,
       drawingMode: CGPathDrawingMode = .eoFill
     ) -> Snapshotting {
       return SimplySnapshotting.image(

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -24,7 +24,7 @@
     ///     match. 98-99% mimics
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
-    public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Snapshotting {
+    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99) -> Snapshotting {
       return SimplySnapshotting.image(
         precision: precision, perceptualPrecision: perceptualPrecision
       ).pullback { path in

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -15,7 +15,7 @@
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
     /// - Returns: A new diffing strategy.
-    public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Diffing {
+    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99) -> Diffing {
       return .init(
         toData: { NSImagePNGRepresentation($0)! },
         fromData: { NSImage(data: $0)! }
@@ -53,7 +53,7 @@
     ///     match. 98-99% mimics
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
-    public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Snapshotting {
+    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99) -> Snapshotting {
       return .init(
         pathExtension: "png",
         diffing: .image(precision: precision, perceptualPrecision: perceptualPrecision)

--- a/Sources/SnapshotTesting/Snapshotting/NSView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSView.swift
@@ -21,7 +21,7 @@
     ///     human eye.
     ///   - size: A view size override.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize? = nil
     ) -> Snapshotting {
       return SimplySnapshotting.image(
         precision: precision, perceptualPrecision: perceptualPrecision

--- a/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
@@ -18,7 +18,7 @@
     ///     human eye.
     ///   - size: A view size override.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize? = nil
     ) -> Snapshotting {
       return Snapshotting<NSView, NSImage>.image(
         precision: precision, perceptualPrecision: perceptualPrecision, size: size

--- a/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
@@ -17,7 +17,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
         -> Snapshotting
       {
         return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
@@ -34,7 +34,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
         -> Snapshotting
       {
         return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)

--- a/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
@@ -17,7 +17,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
         -> Snapshotting
       {
         return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
@@ -34,7 +34,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
         -> Snapshotting
       {
         return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -40,7 +40,7 @@
       public static func image(
         drawHierarchyInKeyWindow: Bool = false,
         precision: Float = 1,
-        perceptualPrecision: Float = 1,
+        perceptualPrecision: Float = 0.99,
         layout: SwiftUISnapshotLayout = .sizeThatFits,
         traits: UITraitCollection = .init(),
         delay: Double? = nil

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -17,7 +17,7 @@
     ///     human eye.
     ///   - scale: The scale to use when loading the reference image from disk.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1
+      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat = 1
     ) -> Snapshotting {
       return SimplySnapshotting.image(
         precision: precision, perceptualPrecision: perceptualPrecision, scale: scale

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -18,7 +18,7 @@
     ///     `UITraitCollection`s default value of `0.0`, the screens scale is used.
     /// - Returns: A new diffing strategy.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat? = nil
     ) -> Diffing {
       let imageScale: CGFloat
       if let scale = scale, scale != 0.0 {
@@ -78,7 +78,7 @@
     ///     human eye.
     ///   - scale: The scale of the reference image stored on disk.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat? = nil
     ) -> Snapshotting {
       return .init(
         pathExtension: "png",

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -25,7 +25,7 @@
     public static func image(
       drawHierarchyInKeyWindow: Bool = false,
       precision: Float = 1,
-      perceptualPrecision: Float = 1,
+      perceptualPrecision: Float = 0.99,
       size: CGSize? = nil,
       traits: UITraitCollection = .init(),
       delay: Double? = nil

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -25,7 +25,7 @@
       on config: ViewImageConfig,
       drawHierarchyInKeyWindow: Bool = false,
       precision: Float = 1,
-      perceptualPrecision: Float = 1,
+      perceptualPrecision: Float = 0.99,
       size: CGSize? = nil,
       traits: UITraitCollection = .init()
     )
@@ -62,7 +62,7 @@
     public static func image(
       drawHierarchyInKeyWindow: Bool = false,
       precision: Float = 1,
-      perceptualPrecision: Float = 1,
+      perceptualPrecision: Float = 0.99,
       size: CGSize? = nil,
       traits: UITraitCollection = .init()
     )


### PR DESCRIPTION
According to gemini:

**precision** checks for exact pixel-by-pixel identity. This is incredibly strict and can lead to flaky tests due to minor, visually imperceptible differences caused by factors like:
- Subtle rendering variations across different CPU architectures (e.g., Intel vs. Apple Silicon).
- Variations in anti-aliasing or gradient rendering.

**perceptualPrecision** evaluates visual differences as perceived by a human eye. It uses advanced color comparison to determine if a discrepancy is actually noticeable. This allows for:
- More robust tests that pass even with minor, non-visual rendering variations.
- Fewer false positives, reducing the need to constantly update snapshots for non-meaningful changes.

So it looks that it's better to change default perceptualPrecision.