### PR TITLE
Change default perceptualPrecision to 0.95

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/CALayer.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CALayer.swift
@@ -25,7 +25,7 @@
     ///     match. 98-99% mimics
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
-    public static func image(precision: Float, perceptualPrecision: Float = 1) -> Snapshotting {
+    public static func image(precision: Float, perceptualPrecision: Float = 0.95) -> Snapshotting {
       return SimplySnapshotting.image(
         precision: precision, perceptualPrecision: perceptualPrecision
       ).pullback { layer in
@@ -59,7 +59,7 @@
     ///     human eye.
     ///   - traits: A trait collection override.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 1, traits: UITraitCollection = .init()
+      precision: Float = 1, perceptualPrecision: Float = 0.95, traits: UITraitCollection = .init()
     )
       -> Snapshotting
     {

--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -28,7 +28,7 @@
     ///   - drawingMode: The drawing mode.
     public static func image(
       precision: Float = 1,
-      perceptualPrecision: Float = 0.99,
+      perceptualPrecision: Float = 0.95,
       drawingMode: CGPathDrawingMode = .eoFill
     ) -> Snapshotting {
       return SimplySnapshotting.image(
@@ -67,7 +67,7 @@
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat = 1,
+      precision: Float = 1, perceptualPrecision: Float = 0.95, scale: CGFloat = 1,
       drawingMode: CGPathDrawingMode = .eoFill
     ) -> Snapshotting {
       return SimplySnapshotting.image(

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -24,7 +24,7 @@
     ///     match. 98-99% mimics
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
-    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99) -> Snapshotting {
+    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.95) -> Snapshotting {
       return SimplySnapshotting.image(
         precision: precision, perceptualPrecision: perceptualPrecision
       ).pullback { path in

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -15,7 +15,7 @@
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
     /// - Returns: A new diffing strategy.
-    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99) -> Diffing {
+    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.95) -> Diffing {
       return .init(
         toData: { NSImagePNGRepresentation($0)! },
         fromData: { NSImage(data: $0)! }
@@ -53,7 +53,7 @@
     ///     match. 98-99% mimics
     ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
     ///     human eye.
-    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99) -> Snapshotting {
+    public static func image(precision: Float = 1, perceptualPrecision: Float = 0.95) -> Snapshotting {
       return .init(
         pathExtension: "png",
         diffing: .image(precision: precision, perceptualPrecision: perceptualPrecision)

--- a/Sources/SnapshotTesting/Snapshotting/NSView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSView.swift
@@ -21,7 +21,7 @@
     ///     human eye.
     ///   - size: A view size override.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.95, size: CGSize? = nil
     ) -> Snapshotting {
       return SimplySnapshotting.image(
         precision: precision, perceptualPrecision: perceptualPrecision

--- a/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
@@ -18,7 +18,7 @@
     ///     human eye.
     ///   - size: A view size override.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.95, size: CGSize? = nil
     ) -> Snapshotting {
       return Snapshotting<NSView, NSImage>.image(
         precision: precision, perceptualPrecision: perceptualPrecision, size: size

--- a/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
@@ -17,7 +17,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.95, size: CGSize)
         -> Snapshotting
       {
         return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
@@ -34,7 +34,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.95, size: CGSize)
         -> Snapshotting
       {
         return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)

--- a/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
@@ -17,7 +17,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.95, size: CGSize)
         -> Snapshotting
       {
         return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
@@ -34,7 +34,7 @@
       ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
       ///     human eye.
       ///   - size: The size of the scene.
-      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.99, size: CGSize)
+      public static func image(precision: Float = 1, perceptualPrecision: Float = 0.95, size: CGSize)
         -> Snapshotting
       {
         return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -40,7 +40,7 @@
       public static func image(
         drawHierarchyInKeyWindow: Bool = false,
         precision: Float = 1,
-        perceptualPrecision: Float = 0.99,
+        perceptualPrecision: Float = 0.95,
         layout: SwiftUISnapshotLayout = .sizeThatFits,
         traits: UITraitCollection = .init(),
         delay: Double? = nil

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -17,7 +17,7 @@
     ///     human eye.
     ///   - scale: The scale to use when loading the reference image from disk.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat = 1
+      precision: Float = 1, perceptualPrecision: Float = 0.95, scale: CGFloat = 1
     ) -> Snapshotting {
       return SimplySnapshotting.image(
         precision: precision, perceptualPrecision: perceptualPrecision, scale: scale

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -18,7 +18,7 @@
     ///     `UITraitCollection`s default value of `0.0`, the screens scale is used.
     /// - Returns: A new diffing strategy.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.95, scale: CGFloat? = nil
     ) -> Diffing {
       let imageScale: CGFloat
       if let scale = scale, scale != 0.0 {
@@ -78,7 +78,7 @@
     ///     human eye.
     ///   - scale: The scale of the reference image stored on disk.
     public static func image(
-      precision: Float = 1, perceptualPrecision: Float = 0.99, scale: CGFloat? = nil
+      precision: Float = 1, perceptualPrecision: Float = 0.95, scale: CGFloat? = nil
     ) -> Snapshotting {
       return .init(
         pathExtension: "png",

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -25,7 +25,7 @@
     public static func image(
       drawHierarchyInKeyWindow: Bool = false,
       precision: Float = 1,
-      perceptualPrecision: Float = 0.99,
+      perceptualPrecision: Float = 0.95,
       size: CGSize? = nil,
       traits: UITraitCollection = .init(),
       delay: Double? = nil

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -25,7 +25,7 @@
       on config: ViewImageConfig,
       drawHierarchyInKeyWindow: Bool = false,
       precision: Float = 1,
-      perceptualPrecision: Float = 0.99,
+      perceptualPrecision: Float = 0.95,
       size: CGSize? = nil,
       traits: UITraitCollection = .init()
     )
@@ -62,7 +62,7 @@
     public static func image(
       drawHierarchyInKeyWindow: Bool = false,
       precision: Float = 1,
-      perceptualPrecision: Float = 0.99,
+      perceptualPrecision: Float = 0.95,
       size: CGSize? = nil,
       traits: UITraitCollection = .init()
     )


### PR DESCRIPTION
Previously we changed perceptualPrecision to 0.99 but it's not enough. Based on some research 0.95 seems to be more correct. Examples below:

| Image Comparison | Description | Precision | Perceptual precision |
|--------|--------|--------|--------|
| <img width="1628" height="636" alt="Screenshot 2025-07-11 at 17 00 19" src="https://github.com/user-attachments/assets/a66978b9-8789-44ac-85b0-62d7c7383515" /> | no visual change | 0.99835587 | 0.99501956 |
| <img width="1566" height="974" alt="Screenshot 2025-07-11 at 16 12 44" src="https://github.com/user-attachments/assets/275e28dc-206f-4027-aa89-2b8c977025f4" /> | no visual change | 0.9990716 | 0.95144534 |
| <img width="1627" height="650" alt="Screenshot 2025-07-11 at 16 10 05" src="https://github.com/user-attachments/assets/357a9dbe-3e8c-47dc-9d46-7d193f2bcff3" /> | no visual change | 0.99945307 | 0.9555078 |
| <img width="1418" height="976" alt="Screenshot 2025-07-11 at 15 51 52" src="https://github.com/user-attachments/assets/0ce26c46-4d35-4eb1-91b0-789a6802c794" /> | close button differ | 0.9990196 | 0.833125 |
| <img width="1402" height="975" alt="Screenshot 2025-07-11 at 16 15 32" src="https://github.com/user-attachments/assets/1f5ed54f-cd77-4cf4-830f-bd21e47b58d0" /> | outdated price differ | 0.99258804 |  0.83953124 |
| <img width="1384" height="970" alt="Screenshot 2025-07-11 at 16 55 16" src="https://github.com/user-attachments/assets/331fe4d9-83f9-4710-b725-da92a686c3a2" /> | outdated price differ | 0.99876404 |  0.83953124 |






