### PR TITLE
Fix snapshot issues when host app using Scene based lifecycle

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -1094,11 +1094,15 @@
 
     private func getKeyWindow() -> UIWindow? {
       var window: UIWindow?
-      if #available(iOS 13.0, *) {
-        window = UIApplication.sharedIfAvailable?.connectedScenes
-          .compactMap { $0 as? UIWindowScene }
-          .flatMap { $0.windows }
-          .first { $0.isKeyWindow }
+      if #available(iOS 13.0, *),
+        let keyWindow = UIApplication.sharedIfAvailable?.connectedScenes
+          .compactMap({ $0 as? UIWindowScene })
+          .flatMap({ $0.windows })
+          .first(where: { $0.isKeyWindow })
+      {
+        window = keyWindow
+      } else if #available(iOS 13.0, *) {
+        window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
       } else {
         window = UIApplication.sharedIfAvailable?.keyWindow
       }
@@ -1113,8 +1117,12 @@
         self.config = config
 
         // Attach to current window scene to ensure consistent safe area behavior
-        let scene = UIApplication.sharedIfAvailable?.connectedScenes.first(where: { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive })
-        if #available(iOS 13.0, *), let windowScene = scene as? UIWindowScene {
+        if #available(iOS 13.0, *),
+          let scene = UIApplication.sharedIfAvailable?.connectedScenes.first(where: {
+            $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive
+          }),
+          let windowScene = scene as? UIWindowScene
+        {
           super.init(windowScene: windowScene)
           self.frame = .init(origin: .zero, size: size)
         } else {

--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -1094,7 +1094,12 @@
 
     private func getKeyWindow() -> UIWindow? {
       var window: UIWindow?
-      if #available(iOS 13.0, *) {
+      if #available(iOS 15.0, *) {
+        window = UIApplication.sharedIfAvailable?.connectedScenes
+          .compactMap { $0 as? UIWindowScene }
+          .flatMap { $0.windows }
+          .first { $0.isKeyWindow }
+      } else if #available(iOS 13.0, *) {
         window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
       } else {
         window = UIApplication.sharedIfAvailable?.keyWindow
@@ -1108,7 +1113,15 @@
       init(config: ViewImageConfig, viewController: UIViewController) {
         let size = config.size ?? viewController.view.bounds.size
         self.config = config
-        super.init(frame: .init(origin: .zero, size: size))
+        // Attach to current window scene to ensure consistent safe area behavior
+        if #available(iOS 13.0, *),
+           let windowScene = UIApplication.sharedIfAvailable?.connectedScenes
+             .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+          super.init(windowScene: windowScene)
+          self.frame = .init(origin: .zero, size: size)
+        } else {
+          super.init(frame: .init(origin: .zero, size: size))
+        }
 
         // NB: Safe area renders inaccurately for UI{Navigation,TabBar}Controller.
         // Fixes welcome!

--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -1094,13 +1094,11 @@
 
     private func getKeyWindow() -> UIWindow? {
       var window: UIWindow?
-      if #available(iOS 15.0, *) {
+      if #available(iOS 13.0, *) {
         window = UIApplication.sharedIfAvailable?.connectedScenes
           .compactMap { $0 as? UIWindowScene }
           .flatMap { $0.windows }
           .first { $0.isKeyWindow }
-      } else if #available(iOS 13.0, *) {
-        window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
       } else {
         window = UIApplication.sharedIfAvailable?.keyWindow
       }
@@ -1113,10 +1111,10 @@
       init(config: ViewImageConfig, viewController: UIViewController) {
         let size = config.size ?? viewController.view.bounds.size
         self.config = config
+
         // Attach to current window scene to ensure consistent safe area behavior
-        if #available(iOS 13.0, *),
-           let windowScene = UIApplication.sharedIfAvailable?.connectedScenes
-             .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+        let scene = UIApplication.sharedIfAvailable?.connectedScenes.first(where: { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive })
+        if #available(iOS 13.0, *), let windowScene = scene as? UIWindowScene {
           super.init(windowScene: windowScene)
           self.frame = .init(origin: .zero, size: size)
         } else {


### PR DESCRIPTION
Since iOS 26 `UIWindow()`, `UIWindow(frame:)` and `UIApplication.shared.windows` have been deprecated so in application which using UISceneDelegate we need to use `connectedScenes` to properly prepare window for snapshots 